### PR TITLE
Remove usage of deprecated functions on sbcl-windows.

### DIFF
--- a/backend/sbcl.lisp
+++ b/backend/sbcl.lisp
@@ -619,7 +619,7 @@ happen. Use with care."
       (raise-usock-err (sockint::wsa-get-last-error) socket)))
 
   (defun os-socket-handle (usocket)
-    (sockint::fd->handle (sb-bsd-sockets:socket-file-descriptor (socket usocket))))
+    (sb-bsd-sockets:socket-file-descriptor (socket usocket)))
 
   (defun bytes-available-for-read (socket)
     (sb-alien:with-alien ((int-ptr sb-alien:unsigned-long))


### PR DESCRIPTION
sockint::fd->handle has been a no-op for a long time and now its usage results in a warning.