### PR TITLE
fix backquoting issue passing :external-format arg

### DIFF
--- a/backend/openmcl.lisp
+++ b/backend/openmcl.lisp
@@ -117,7 +117,7 @@
 			      ,@(when local
 				  `(:local-address ,local))
 			      :format ,(to-format element-type protocol)
-			      :external-format ccl:*default-external-format*
+			      :external-format ,ccl:*default-external-format*
 			      :deadline ,deadline
 			      :nodelay ,nodelay
 			      :connect-timeout ,timeout


### PR DESCRIPTION
Ccl:\*default-external-format\* appears in a backquoted list, but it was missing the comma it needed to get evaluated.