### PR TITLE
[CCL] Translate host to hostname

### DIFF
--- a/backend/openmcl.lisp
+++ b/backend/openmcl.lisp
@@ -96,7 +96,7 @@
     (ecase protocol
       (:stream
        (let ((mcl-sock
-	      (openmcl-socket:make-socket :remote-host host
+	      (openmcl-socket:make-socket :remote-host (host-to-hostname host)
 					  :remote-port port
 					  :local-host local-host
 					  :local-port local-port


### PR DESCRIPTION
Hi,

the other day I was playing with [cl-redis](https://github.com/vseloved/cl-redis) on CCL 1.10. I ran into the bug, that sockets cannot be created in CCL with vector quad hosts. 

Steps to reproduce this bug:

1. Load `usocket` into your CCL image (obviously)
2. Run 
```lisp
CL-USER> (usocket:socket-connect #(127 0 0 1) 6379) ; default Redis host and port
```
This presents me:
```
The value #(127 0 0 1) is not of the expected type (OR
                                                    INTEGER
                                                    STRING).
   [Condition of type TYPE-ERROR]

Restarts:
 0: [RETRY] Retry SLIME REPL evaluation request.
 1: [*ABORT] Return to SLIME's top level.
 2: [ABORT-BREAK] Reset this thread
 3: [ABORT] Kill this thread

Backtrace:
  0: (CCL::HOST-AS-INET-HOST #(127 0 0 1))
  1: (CCL::MAKE-TCP-STREAM-SOCKET 27 :REMOTE-HOST #(127 0 0 1) :REMOTE-PORT 6379 :LOCAL-HOST NIL :LOCAL-PORT NIL :FORMAT :TEXT :EXTERNAL-FORMAT :UNIX :DEADLINE NIL :NODELAY NIL :CONNECT-TIMEOUT NIL)
  2: (CCL::MAKE-TCP-SOCKET :REMOTE-HOST #(127 0 0 1) :REMOTE-PORT 6379 :LOCAL-HOST NIL :LOCAL-PORT NIL :FORMAT :TEXT :EXTERNAL-FORMAT :UNIX :DEADLINE NIL :NODELAY NIL :CONNECT-TIMEOUT NIL)
  3: (MAKE-SOCKET :REMOTE-HOST #(127 0 0 1) :REMOTE-PORT 6379 :LOCAL-HOST NIL :LOCAL-PORT NIL :FORMAT :TEXT :EXTERNAL-FORMAT :UNIX :DEADLINE NIL :NODELAY NIL :CONNECT-TIMEOUT NIL)
  4: (USOCKET:SOCKET-CONNECT #(127 0 0 1) 6379 :PROTOCOL :STREAM :ELEMENT-TYPE NIL :TIMEOUT NIL :DEADLINE NIL :NODELAY NIL :LOCAL-HOST NIL :LOCAL-PORT NIL)
  5: (CCL::CALL-CHECK-REGS USOCKET:SOCKET-CONNECT #(127 0 0 1) 6379)
  6: (CCL::CHEAP-EVAL (USOCKET:SOCKET-CONNECT #(127 0 0 1) 6379))
 --more--
```

This PR aims to fix it by explicitly translating the host in to its hostname.

Best (and keep up the good work),

Sebastian