### PR TITLE
[ECL] include unistd.h for gethostname

### DIFF
--- a/backend/sbcl.lisp
+++ b/backend/sbcl.lisp
@@ -32,7 +32,8 @@
   #-:wsock
   (ffi:clines
    "#include <errno.h>"
-   "#include <sys/socket.h>")
+   "#include <sys/socket.h>"
+   "#include <unistd.h>")
   #+:wsock
   (ffi:clines
    "#ifndef FD_SETSIZE"


### PR DESCRIPTION
On some platforms there is warning about implicit functio declaration

One such platform is ArchLinuxARM na armv7h - apparently socket.h doesn't have include of unistd.h, or something of this kind