### PR TITLE
Fixed a broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ layer a flexi-stream (from flexi-streams) on top of a usocket stream.
  - unkown-condition
 
 (for a description of the API methods and functions see
-  http://common-lisp.net/project/usocket/api-docs.shtml.)
+  https://common-lisp.net/project/usocket/api-docs.shtml)
 
 # Test suite
 

--- a/package.lisp
+++ b/package.lisp
@@ -3,7 +3,6 @@
 (defpackage :usocket
   (:use :common-lisp #+abcl :java)
   (:export   #:*version*
-
              #:*wildcard-host*
              #:*auto-port*
 
@@ -23,6 +22,7 @@
              #:get-peer-port
              #:get-local-name
              #:get-peer-name
+             #:listen
 
              #:socket-send    ; udp function (send)
              #:socket-receive ; udp function (receive)


### PR DESCRIPTION
Your link to the API documentation is broken. Common-lisp.net has added SSL support on their website.

Also, the `listen` function should be external, it is listed in the API documentation as something that should be used.

Thanks!