### PR TITLE
fix wait-for-input for clisp

### DIFF
--- a/backend/clisp.lisp
+++ b/backend/clisp.lisp
@@ -250,7 +250,7 @@
                             (socket:socket-status request-list)))
              (sockets (wait-list-waiters wait-list)))
         (do* ((x (pop sockets) (pop sockets))
-              (y (cdr (pop status-list)) (cdr (pop status-list))))
+              (y (pop status-list) (pop status-list)))
              ((null x))
           (when (member y '(T :INPUT))
             (setf (state x) :READ)))


### PR DESCRIPTION
cl-mongo was unable to make database queries when running in clisp. I tracked the problem down to this one line. Changing it as shown fixed things for me.