### PR TITLE
Add UDP broadcast support for LispWorks

### DIFF
--- a/backend/lispworks.lisp
+++ b/backend/lispworks.lisp
@@ -101,6 +101,11 @@
   (tv-sec :long)
   (tv-usec :long))
 
+(defconstant *sockopt_so_broadcast*
+  #-linux #x0020
+  #+linux 6
+  "Socket broadcast")
+
 ;;; ssize_t
 ;;; recvfrom(int socket, void *restrict buffer, size_t length, int flags,
 ;;;          struct sockaddr *restrict address, socklen_t *restrict address_len);

--- a/backend/lispworks.lisp
+++ b/backend/lispworks.lisp
@@ -290,6 +290,33 @@
                                  len))
         zero-or-one 0))) ; on error, return 0
 
+(defun get-socket-broadcast (socket-fd)
+  "Get socket option: SO_BROADCAST, return value is a fixnum (0 or 1)"
+  (declare (type integer socket-fd))
+  (fli:with-dynamic-foreign-objects ((zero-or-one :int)
+                                     (len :int))
+    (if (zerop (comm::getsockopt socket-fd
+                                 comm::*sockopt_sol_socket*
+				 *sockopt_so_broadcast*
+                                 (fli:copy-pointer zero-or-one
+                                                   :type '(:pointer #+win32 :char #-win32 :void))
+                                 len))
+        zero-or-one 0)))
+
+(defun set-socket-broadcast (socket-fd new-value)
+  "Set socket option: SO_BROADCAST, argument is a fixnum (0 or 1)"
+  (declare (type integer socket-fd)
+           (type (integer 0 1) new-value))
+  (fli:with-dynamic-foreign-objects ((zero-or-one :int))
+    (setf (fli:dereference zero-or-one) new-value)
+    (when (zerop (comm::setsockopt socket-fd
+                                   comm::*sockopt_sol_socket*
+                                   *sockopt_so_broadcast*
+                                   (fli:copy-pointer zero-or-one
+                                                     :type '(:pointer #+win32 :char #-win32 :void))
+                                   (fli:size-of :int)))
+        new-value)))
+
 (defun initialize-dynamic-sockaddr (hostname service protocol &aux (original-hostname hostname))
   (declare (ignorable original-hostname))
   #+(or lispworks4 lispworks5 lispworks6.0)

--- a/backend/lispworks.lisp
+++ b/backend/lispworks.lisp
@@ -414,7 +414,7 @@
 	(when (string= hostname "255.255.255.255")
 	  ;; LispWorks fails on connect if the broadcast option for broadcast
 	  ;; address is not set in advance
-	  (usocket::set-socket-broadcast socket-fd 1))
+	  (set-socket-broadcast socket-fd 1))
         (if socket-fd
             (if (comm::connect socket-fd server-addr server-addr-length)
                 ;; success, return socket fd

--- a/backend/lispworks.lisp
+++ b/backend/lispworks.lisp
@@ -399,7 +399,7 @@
       (error "cannot create socket"))))
 
 (defun connect-to-udp-server (hostname service
-                                       &key local-address local-port read-timeout)
+                                       &key local-address local-port read-timeout broadcast)
   "Something like CONNECT-TO-TCP-SERVER"
   (fli:with-dynamic-foreign-objects ()
     (multiple-value-bind (error address-family server-addr server-addr-length)
@@ -411,6 +411,7 @@
                                         :local-port local-port
                                         :read-timeout read-timeout
                                         :address-family address-family)))
+	(usocket::set-socket-broadcast socket-fd (bool->int broadcast))
         (if socket-fd
             (if (comm::connect socket-fd server-addr server-addr-length)
                 ;; success, return socket fd
@@ -423,7 +424,7 @@
 
 (defun socket-connect (host port &key (protocol :stream) (element-type 'base-char)
                        timeout deadline (nodelay t)
-                       local-host local-port)
+                       local-host local-port broadcast)
   ;; What's the meaning of this keyword?
   (when deadline
     (unimplemented 'deadline 'socket-connect))
@@ -477,6 +478,7 @@
                            (connect-to-udp-server (host-to-hostname host) port
                                                   :local-address (and local-host (host-to-hostname local-host))
                                                   :local-port local-port
+						  :broadcast broadcast
                                                   :read-timeout timeout))
                          (with-mapped-conditions (nil local-host)
                            (open-udp-socket       :local-address (and local-host (host-to-hostname local-host))

--- a/option.lisp
+++ b/option.lisp
@@ -235,7 +235,7 @@
     #+(or ecl clasp)
     () ; TODO
     #+lispworks
-    () ; TODO
+    (int->bool (get-socket-tcp-nodelay socket))
     #+mcl
     () ; TODO
     #+mocl
@@ -264,7 +264,7 @@
     #+(or ecl clasp)
     () ; TODO
     #+lispworks
-    () ; TODO
+    (set-socket-broadcast socket (bool->int new-value))
     #+mcl
     () ; TODO
     #+mocl


### PR DESCRIPTION
Added the get/set-broadcast calls for LispWorks. However they alone are of little help, since LW fails on COMM::CONNECT if the host parameter is the broadcast address.

Hence a check for zero-network address was added in CONNECT-TO-UDP-SERVER and appears to do the job. Hacky, so any better ideas are welcome.