### PR TITLE
[SBCL] Fix type assertion compiler note

### DIFF
--- a/backend/sbcl.lisp
+++ b/backend/sbcl.lisp
@@ -592,7 +592,8 @@ happen. Use with care."
   (declare (values (simple-array (unsigned-byte 8) (*)) ; buffer
 		   (integer 0)                          ; size
 		   (simple-array (unsigned-byte 8) (*)) ; host
-		   (unsigned-byte 16)))                 ; port
+		   (unsigned-byte 16)                   ; port
+                   &optional))
   (with-mapped-conditions (usocket)
     (let ((s (socket usocket)))
       (sb-bsd-sockets:socket-receive s buffer length :element-type element-type))))


### PR DESCRIPTION
> ; in: DEFMETHOD SOCKET-RECEIVE (DATAGRAM-USOCKET T T)
> ; note: Type assertion too complex to check:
> ; (VALUES (SIMPLE-ARRAY (UNSIGNED-BYTE 8) (*)) UNSIGNED-BYTE
> ;         (SIMPLE-ARRAY (UNSIGNED-BYTE 8) (*)) (UNSIGNED-BYTE 16) &REST T).
> ; It allows an unknown number of values, consider using
> ; (VALUES (SIMPLE-ARRAY (UNSIGNED-BYTE 8) (*)) UNSIGNED-BYTE
> ;         (SIMPLE-ARRAY (UNSIGNED-BYTE 8) (*)) (UNSIGNED-BYTE 16) &OPTIONAL).

- Add `&OPTIONAL` to DEFMETHOD SOCKET-RECEIVE type declaration
- Now only declared values should be allowed.