### PR TITLE
Make grammatical and markup changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 https://common-lisp.net/project/usocket/
 
-This is the usocket Common Lisp sockets library: a library to bring
-sockets access to the broadest of common lisp implementations as possible.
+This is the `usocket` Common Lisp sockets library - a library to bring
+sockets access to the broadest of Common Lisp implementations as possible.
 
 ## The library currently supports:
 
@@ -23,89 +23,93 @@ sockets access to the broadest of common lisp implementations as possible.
 14. Scieneer CL
 15. Symbolics Lisp Machine (Genera)
 
-If your favorite common lisp misses in the list above, please contact
+If your favorite Common Lisp is missing from the above list, please contact
 usocket-devel@common-lisp.net and submit a request.  Please include
-references to available sockets functions in your lisp implementation.
+references to available sockets functions in your Lisp implementation.
 
-The library has been ASDF (http://cliki.net/ASDF) enabled, meaning
-that you can tar up a checkout and use that to ASDF-INSTALL:INSTALL
+The library is [ASDF](http://cliki.net/ASDF)-enabled, meaning
+that you can tar up a checkout and use that to `asdf-install:install`
 the package in your system package site.  (Or use your usual ASDF
 tricks to use the checkout directly.)
 
 ## Remarks on licensing
 
-Even though the source code has an MIT style license attached to it,
-when compiling this code with some of the supported lisp implementations
-you may not end up with an MIT style binary version due to the licensing
+Even though the source code has an MIT-style license attached to it,
+when compiling this code with some of the supported Lisp implementations
+you may not end up with an MIT-style binary version due to the licensing
 of the implementations themselves.  ECL is such an example and - when
-it will become supported - GCL is like that too.
+it comes to be supported - so is GCL.
 
 ## Non-support of :external-format
 
-Because of its definition in the hyperspec, there's no common
-external-format between lisp implementations: every vendor has chosen
+Because of its definition in the Hyperspec, there's no common
+external-format between Lisp implementations: every vendor has chosen
 a different way to solve the problem of newline translation or
 character set recoding.
 
-Because there's no way to avoid platform specific code in the application
+Because there's no way to avoid platform-specific code in the application
 when using external-format, the purpose of a portability layer gets
-defeated.  So, for now, usocket doesn't support external-format.
+defeated.  So, for now, `usocket` doesn't support external-format.
 
 The workaround to get reasonably portable external-format support is to
-layer a flexi-stream (from flexi-streams) on top of a usocket stream.
+layer a `flexi-stream` (from `flexi-streams`) on top of a `usocket` stream.
 
 ## API definition
 
- - usocket (class)
- - stream-usocket (class; usocket derivative)
- - stream-server-usocket (class; usocket derivative)
- - socket-connect (function) [ to create an active/connected socket ]
-    socket-connect host port &key element-type
-      where `host' is a vectorized ip
-                      or a string representation of a dotted ip address
-                      or a hostname for lookup in the DNS system
- - socket-listen (function) [ to create a passive/listening socket ]
-     socket-listen host port &key reuseaddress backlog element-type
-       where `host' has the same definition as above
- - socket-accept (method) [ to create an active/connected socket ]
-     socket-accept socket &key element-type
-       returns (server side) a connected socket derived from a
-       listening/passive socket.
- - socket-close (method)
-    socket-close socket
-      where socket a previously returned socket
- - socket (usocket slot accessor),
-      the internal/implementation defined socket representation
- - socket-stream (usocket slot accessor),
-    socket-stream socket
-      the return value of which satisfies the normal stream interface
- - socket-shutdown
+ - `usocket` (class)
+ - `stream-usocket` (class; usocket derivative)
+ - `stream-server-usocket` (class; usocket derivative)
+ - `socket-connect (host port &key element-type)` (function) 
+ 
+   Create an active/connected socket. `host` can be a vectorized IP, or a string representation of a dotted IP address, or a hostname for lookup in the DNS system.
+   
+ - `socket-listen (host port &key reuseaddress backlog element-type)` (function) 
+ 
+   Create a passive/listening socket. For possible values of `host`, see `socket-connect`.
+   
+ - `socket-accept (socket &key element-type)` (method)
+
+   Create an active/connected socket. Returns (server side) a connected socket derived from a listening/passive socket.
+   
+ - `socket-close (socket)` (method)
+ 
+   Where `socket` is a previously-returned socket.
+   
+ - `socket` (usocket slot accessor),
+ 
+   Returns the internal/implementation-defined socket representation.
+   
+ - `socket-stream (socket)` (usocket slot accessor),
+    
+   Returns a value which satisfies the normal stream interface.
+   
+ - `socket-shutdown`
 
 ### Errors:
- - address-in-use-error
- - address-not-available-error
- - bad-file-descriptor-error
- - connection-refused-error
- - connection-aborted-error
- - connection-reset-error
- - invalid-argument-error
- - no-buffers-error
- - operation-not-supported-error
- - operation-not-permitted-error
- - protocol-not-supported-error
- - socket-type-not-supported-error
- - network-unreachable-error
- - network-down-error
- - network-reset-error
- - host-down-error
- - host-unreachable-error
- - shutdown-error
- - timeout-error
- - unkown-error
+ - `address-in-use-error`
+ - `address-not-available-error`
+ - `bad-file-descriptor-error`
+ - `connection-refused-error`
+ - `connection-aborted-error`
+ - `connection-reset-error`
+ - `invalid-argument-error`
+ - `no-buffers-error`
+ - `operation-not-supported-error`
+ - `operation-not-permitted-error`
+ - `protocol-not-supported-error`
+ - `socket-type-not-supported-error`
+ - `network-unreachable-error`
+ - `network-down-error`
+ - `network-reset-error`
+ - `host-down-error`
+ - `host-unreachable-error`
+ - `shutdown-error`
+ - `timeout-error`
+ - `unkown-error`
 
 ### Non-fatal conditions:
- - interrupted-condition
- - unkown-condition
+ - `interrupted-condition`
+ - `unkown-condition`
 
 (for a description of the API methods and functions see
   https://common-lisp.net/project/usocket/api-docs.shtml)
@@ -117,11 +121,11 @@ some manual configuration.  Several elements are required which are
 hard to programatically detect.  Please adjust the test file before
 running the tests, for these variables:
 
-- +non-existing-host+: The stringified IP address of a host on the
+- `+non-existing-host+`: The stringified IP address of a host on the
      same subnet.  No physical host may be present.
-- +unused-local-port+: A port number of a port not in use on the
+- `+unused-local-port+`: A port number of a port not in use on the
      machine the tests run on.
-- +common-lisp-net+: A vector with 4 integer elements which make up
+- `+common-lisp-net+`: A vector with 4 integer elements which make up
      an IP address. This must be the IP "common-lisp.net" resolves to.
 
 ## Known problems
@@ -132,12 +136,12 @@ running the tests, for these variables:
 
 - The ArmedBear backend doesn't do any error mapping (yet). Java
   defines exceptions at the wrong level (IMO), since the exception
-  reported bares a relation to the function failing, not the actual
+  reported bears a relation to the function failing, not the actual
   error that occurred: for example 'Address already in use' (when
-  creating a passive socket) is reported as a BindException with
+  creating a passive socket) is reported as a `BindException` with
   an error text of 'Address already in use'. There's no way to sanely
-  map 'BindException' to a meaningfull error in usocket. [This does not
-  mean the backend should not at least map to 'unknown-error'!]
+  map `BindException` to a meaningfull error in usocket. [This does not
+  mean the backend should not at least map to `unknown-error`!]
 
 - When using the library with ECL, you need the C compiler installed
   to be able to compile and load the Foreign Function Interface.


### PR DESCRIPTION
This includes -
1. Some capitalization changes
2. Use of backticks for identifiers, signatures, and parameters
3. Rephrasing of API documentation