### PR TITLE
[socket-connect] Provide restarts to interactively set host and port

### DIFF
--- a/backend/abcl.lisp
+++ b/backend/abcl.lisp
@@ -190,7 +190,7 @@
 
 ;;; SOCKET-CONNECT
 
-(defun socket-connect (host port &key (protocol :stream) (element-type 'character)
+(defun socket-connect-internal (host port &key (protocol :stream) (element-type 'character)
                        timeout deadline (nodelay t nodelay-supplied-p)
                        local-host local-port)
   (when deadline (unsupported 'deadline 'socket-connect))

--- a/backend/allegro.lisp
+++ b/backend/allegro.lisp
@@ -55,7 +55,7 @@
       :text
     :binary))
 
-(defun socket-connect (host port &key (protocol :stream) (element-type 'character)
+(defun socket-connect-internal (host port &key (protocol :stream) (element-type 'character)
                        timeout deadline
                        (nodelay t) ;; nodelay == t is the ACL default
                        local-host local-port)

--- a/backend/clisp.lisp
+++ b/backend/clisp.lisp
@@ -126,7 +126,7 @@
                       (t
                        (signal usock-error :socket socket))))))))))
 
-(defun socket-connect (host port &key (protocol :stream) (element-type 'character)
+(defun socket-connect-internal (host port &key (protocol :stream) (element-type 'character)
                        timeout deadline (nodelay t nodelay-specified)
                        local-host local-port)
   (declare (ignorable timeout local-host local-port))

--- a/backend/clozure.lisp
+++ b/backend/clozure.lisp
@@ -5,7 +5,7 @@
 (in-package :usocket)
 
 #+ipv6
-(defun socket-connect (host port &key
+(defun socket-connect-internal (host port &key
                        (protocol :stream) element-type
                        timeout deadline nodelay local-host local-port)
   (when (eq nodelay :if-supported)

--- a/backend/cmucl.lisp
+++ b/backend/cmucl.lisp
@@ -54,7 +54,7 @@
                                                :condition condition
                                                :host-or-ip host-or-ip))))
 
-(defun socket-connect (host port &key (protocol :stream) (element-type 'character)
+(defun socket-connect-internal (host port &key (protocol :stream) (element-type 'character)
                        timeout deadline (nodelay t nodelay-specified)
 		       (local-host nil local-host-p)
 		       (local-port nil local-port-p)

--- a/backend/genera.lisp
+++ b/backend/genera.lisp
@@ -62,7 +62,7 @@
     (sys:network-error
       (error 'unknown-error :socket socket :real-error condition :errno -1))))
 
-(defun socket-connect (host port &key (protocol :stream) element-type
+(defun socket-connect-internal (host port &key (protocol :stream) element-type
 			    timeout deadline (nodelay nil nodelay-p)
 			    local-host local-port)
   (declare (ignore local-host))

--- a/backend/iolib.lisp
+++ b/backend/iolib.lisp
@@ -78,7 +78,7 @@
 (defun ipv6-address-p (host)
   (iolib/sockets:ipv6-address-p (iolib/sockets:ensure-hostname host)))
 
-(defun socket-connect (host port &key (protocol :stream) (element-type 'character)
+(defun socket-connect-internal (host port &key (protocol :stream) (element-type 'character)
                        timeout deadline
                        (nodelay t) ;; nodelay == t is the ACL default
                        local-host local-port)

--- a/backend/lispworks.lisp
+++ b/backend/lispworks.lisp
@@ -454,7 +454,7 @@
                 (error "cannot connect")))
           (error "cannot create socket"))))))
 
-(defun socket-connect (host port &key (protocol :stream) (element-type 'base-char)
+(defun socket-connect-internal (host port &key (protocol :stream) (element-type 'base-char)
                        timeout deadline (nodelay t)
                        local-host local-port)
   ;; What's the meaning of this keyword?

--- a/backend/mcl.lisp
+++ b/backend/mcl.lisp
@@ -22,7 +22,7 @@
       (ccl:opentransport-protocol-error
        (raise-error 'protocol-not-supported-error)))))
 
-(defun socket-connect (host port &key (element-type 'character) timeout deadline nodelay 
+(defun socket-connect-internal (host port &key (element-type 'character) timeout deadline nodelay 
                             local-host local-port (protocol :stream))
   (when (eq nodelay :if-supported)
     (setf nodelay t))

--- a/backend/mezzano.lisp
+++ b/backend/mezzano.lisp
@@ -10,7 +10,7 @@
     (mezzano.network.tcp:connection-timed-out
      (error 'timeout-error :socket socket))))
 
-(defun socket-connect (host port &key (protocol :stream) element-type
+(defun socket-connect-internal (host port &key (protocol :stream) element-type
                                       timeout deadline (nodelay nil nodelay-p)
                                       local-host local-port)
   (declare (ignore local-host local-port))

--- a/backend/mocl.lisp
+++ b/backend/mocl.lisp
@@ -7,7 +7,7 @@
   (declare (ignore socket))
   (signal condition))
 
-(defun socket-connect (host port &key (protocol :stream) (element-type 'character)
+(defun socket-connect-internal (host port &key (protocol :stream) (element-type 'character)
                        timeout deadline (nodelay t nodelay-specified)
 		       (local-host nil local-host-p)
 		       (local-port nil local-port-p))

--- a/backend/openmcl.lisp
+++ b/backend/openmcl.lisp
@@ -89,7 +89,7 @@
 	 :bivalent)))
 
 #-ipv6
-(defun socket-connect (host port &key (protocol :stream) element-type
+(defun socket-connect-internal (host port &key (protocol :stream) element-type
 		       timeout deadline nodelay
 		       local-host local-port)
   (when (eq nodelay :if-supported)

--- a/backend/sbcl.lisp
+++ b/backend/sbcl.lisp
@@ -405,7 +405,7 @@ happen. Use with care."
         (and (or ecl mkcl) (not (or darwin linux openbsd freebsd netbsd bsd))))
   nil)
 
-(defun socket-connect (host port &key (protocol :stream) (element-type 'character)
+(defun socket-connect-internal (host port &key (protocol :stream) (element-type 'character)
                        timeout deadline (nodelay t nodelay-specified)
                        local-host local-port
                        &aux

--- a/backend/scl.lisp
+++ b/backend/scl.lisp
@@ -25,7 +25,7 @@
 			   :socket socket
 			   :condition condition))))
 
-(defun socket-connect (host port &key (protocol :stream) (element-type 'character)
+(defun socket-connect-internal (host port &key (protocol :stream) (element-type 'character)
                        timeout deadline (nodelay t nodelay-specified)
 		       (local-host nil local-host-p)
 		       (local-port nil local-port-p)

--- a/usocket.lisp
+++ b/usocket.lisp
@@ -762,6 +762,29 @@ backward compatibility (but deprecated); when both `reuseaddress' and
         (retry ()
 	  :report "Retry socket connection.")))))
 
+(defun socket-connect (host port &rest args)
+  (let ((socket-host host)
+	(socket-port port))
+    (loop 
+      (restart-case (return
+                     (apply #'socket-connect-internal socket-host socket-port args))
+	(use-other-port (new-port) 
+          :report "Use a different port." 
+          :interactive 
+          (lambda ()
+	    (format *query-io* "Port: ")
+            (list (parse-integer (read-line *query-io*))))
+	  (setq socket-port new-port))
+	(use-other-host (new-host) 
+          :report "Use a different host." 
+          :interactive 
+          (lambda ()
+	    (format *query-io* "Host: ")
+            (list (read-line *query-io*)))
+	  (setq socket-host new-host))
+        (retry ()
+	  :report "Retry socket connection.")))))
+
 ;; This convenient macro is contributed by Jay Mellor (https://github.com/JayMellor)
 ;;
 (defmacro with-accepted-connection ((conn &rest socket-accept-args)


### PR DESCRIPTION
Add restarts to socket-connect .

Issue #99 