### PR TITLE
Update and supply documentation for most exported symbols

### DIFF
--- a/condition.lisp
+++ b/condition.lisp
@@ -47,8 +47,8 @@ been implemented yet."))
 
 (define-condition socket-condition (condition)
   ((socket :initarg :socket
-           :accessor usocket-socket))
-  ;;###FIXME: no slots (yet); should at least be the affected usocket...
+           :accessor usocket-socket
+           :documentation "Socket that raised the condition"))
   (:documentation "Parent condition for all socket related conditions."))
 
 (define-condition socket-error (socket-condition error)
@@ -194,6 +194,9 @@ condition available."))
 error available."))
 
 (defmacro with-mapped-conditions ((&optional socket host-or-ip) &body body)
+  "Run `body', handling implementation-specific conditions by re-raising them as usocket conditions.
+
+When `socket' or `host-or-ip' are specified, their values will be passed as arguments to the corresponding usocket conditions."
   `(handler-bind ((condition
                    #'(lambda (c) (handle-condition c ,socket ,host-or-ip))))
      ,@body))


### PR DESCRIPTION
This commit goes through most of the package's exported symbols, updating docstrings where needed and adding docstrings to most undocumented functions and variables.

The following docstrings have been added or updated:
+ socket-connect
+ get-local-address
+ get-peer-address
+ socket-send
+ socket-receive
+ wait-for-input
+ make-wait-list
+ add-waiter
+ remove-waiter
+ remove-all-waiters
+ usocket-p
+ stream-usocket-p
+ stream-server-usocket-p
+ datagram-usocket-p
+ hbo-to-dotted-quad
+ hbo-to-vector-quad
+ vector-quad-to-dotted-quad
+ dotted-quad-to-vector-quad
+ vector-to-ipv6-host
+ ipv6-host-to-vector
+ ip=
+ ip/=
+ integer-to-octet-buffer
+ octet-buffer-to-integer
+ port-to-octet-buffer
+ port-from-octet-buffer
+ ip-to-octet-buffer
+ ip-from-octet-buffer
+ with-mapped-conditions
+ socket-server
+ *remote-host*
+ *remote-port*
+ get-host-by-name
+ get-hosts-by-name
+ get-random-host-by-name
+ default-upd-handler
+ default-tcp-handler
+ echo-tcp-handler
+ *backend*