### PR TITLE
support domain socket on SBCL/*nix

### DIFF
--- a/backend/abcl.lisp
+++ b/backend/abcl.lisp
@@ -190,7 +190,7 @@
 
 ;;; SOCKET-CONNECT
 
-(defun socket-connect-internal (host port &key (protocol :stream) (element-type 'character)
+(defun socket-connect-internal (host &key port (protocol :stream) (element-type 'character)
                        timeout deadline (nodelay t nodelay-supplied-p)
                        local-host local-port)
   (when deadline (unsupported 'deadline 'socket-connect))

--- a/backend/abcl.lisp
+++ b/backend/abcl.lisp
@@ -236,7 +236,7 @@
 ;;; SOCKET-LISTEN
 
 (defun socket-listen-internal
-                     (host port &key reuseaddress
+                     (host &key port reuseaddress
                       (reuse-address nil reuse-address-supplied-p)
 		      (backlog 5 backlog-supplied-p)
 		      (element-type 'character))

--- a/backend/allegro.lisp
+++ b/backend/allegro.lisp
@@ -118,8 +118,7 @@
         (socket:shutdown (socket usocket) :direction direction))))
 
 (defun socket-listen-internal
-                          (host port
-                           &key reuseaddress
+                          (host &key port reuseaddress
                            (reuse-address nil reuse-address-supplied-p)
                            (backlog 5)
                            (element-type 'character))

--- a/backend/allegro.lisp
+++ b/backend/allegro.lisp
@@ -55,7 +55,7 @@
       :text
     :binary))
 
-(defun socket-connect-internal (host port &key (protocol :stream) (element-type 'character)
+(defun socket-connect-internal (host &key port (protocol :stream) (element-type 'character)
                        timeout deadline
                        (nodelay t) ;; nodelay == t is the ACL default
                        local-host local-port)

--- a/backend/clisp.lisp
+++ b/backend/clisp.lisp
@@ -161,8 +161,7 @@
      (unsupported '(protocol :datagram) 'socket-connect))))
 
 (defun socket-listen-internal
-                          (host port
-                           &key reuseaddress
+                          (host &key port reuseaddress
                            (reuse-address nil reuse-address-supplied-p)
                            (backlog 5)
                            (element-type 'character))

--- a/backend/clisp.lisp
+++ b/backend/clisp.lisp
@@ -126,7 +126,7 @@
                       (t
                        (signal usock-error :socket socket))))))))))
 
-(defun socket-connect-internal (host port &key (protocol :stream) (element-type 'character)
+(defun socket-connect-internal (host &key port (protocol :stream) (element-type 'character)
                        timeout deadline (nodelay t nodelay-specified)
                        local-host local-port)
   (declare (ignorable timeout local-host local-port))

--- a/backend/clozure.lisp
+++ b/backend/clozure.lisp
@@ -59,7 +59,7 @@
 
 #+ipv6
 (defun socket-listen-internal
-                     (host port &key
+                     (host &key port
                       (reuse-address nil reuse-address-supplied-p)
                       (reuseaddress (when reuse-address-supplied-p reuse-address))
                       (backlog 5)

--- a/backend/clozure.lisp
+++ b/backend/clozure.lisp
@@ -5,7 +5,7 @@
 (in-package :usocket)
 
 #+ipv6
-(defun socket-connect-internal (host port &key
+(defun socket-connect-internal (host &key port
                        (protocol :stream) element-type
                        timeout deadline nodelay local-host local-port)
   (when (eq nodelay :if-supported)

--- a/backend/cmucl.lisp
+++ b/backend/cmucl.lisp
@@ -54,7 +54,7 @@
                                                :condition condition
                                                :host-or-ip host-or-ip))))
 
-(defun socket-connect-internal (host port &key (protocol :stream) (element-type 'character)
+(defun socket-connect-internal (host &key port (protocol :stream) (element-type 'character)
                        timeout deadline (nodelay t nodelay-specified)
 		       (local-host nil local-host-p)
 		       (local-port nil local-port-p)

--- a/backend/cmucl.lisp
+++ b/backend/cmucl.lisp
@@ -119,8 +119,7 @@
 	     (when err (cmucl-map-socket-error err))))))))
 
 (defun socket-listen-internal
-                          (host port
-                           &key reuseaddress
+                          (host &key port reuseaddress
                            (reuse-address nil reuse-address-supplied-p)
                            (backlog 5)
                            (element-type 'character))

--- a/backend/genera.lisp
+++ b/backend/genera.lisp
@@ -128,7 +128,7 @@
 		  (setq tcp::*last-gensym-port-number* #.(expt 2 10))))))
 
 (defun socket-listen-internal
-                     (host port &key (reuse-address nil reuse-address-p)
+                     (host &key port (reuse-address nil reuse-address-p)
 				     (reuseaddress nil reuseaddress-p)
 				     (backlog 5) (element-type 'character))
   (let ((host-object (host-to-host-object host))

--- a/backend/genera.lisp
+++ b/backend/genera.lisp
@@ -62,7 +62,7 @@
     (sys:network-error
       (error 'unknown-error :socket socket :real-error condition :errno -1))))
 
-(defun socket-connect-internal (host port &key (protocol :stream) element-type
+(defun socket-connect-internal (host &key port (protocol :stream) element-type
 			    timeout deadline (nodelay nil nodelay-p)
 			    local-host local-port)
   (declare (ignore local-host))

--- a/backend/iolib.lisp
+++ b/backend/iolib.lisp
@@ -78,7 +78,7 @@
 (defun ipv6-address-p (host)
   (iolib/sockets:ipv6-address-p (iolib/sockets:ensure-hostname host)))
 
-(defun socket-connect-internal (host port &key (protocol :stream) (element-type 'character)
+(defun socket-connect-internal (host &key port (protocol :stream) (element-type 'character)
                        timeout deadline
                        (nodelay t) ;; nodelay == t is the ACL default
                        local-host local-port)

--- a/backend/iolib.lisp
+++ b/backend/iolib.lisp
@@ -125,8 +125,8 @@
        (iolib/sockets:shutdown (socket usocket) :read t :write t)))))
 
 (defun socket-listen-internal
-                          (host port
-                           &key reuseaddress reuse-address
+                          (host &key port reuseaddress
+                           reuse-address
                            (backlog 5)
                            (element-type 'character))
   (declare (ignore element-type))

--- a/backend/lispworks.lisp
+++ b/backend/lispworks.lisp
@@ -454,7 +454,7 @@
                 (error "cannot connect")))
           (error "cannot create socket"))))))
 
-(defun socket-connect-internal (host port &key (protocol :stream) (element-type 'base-char)
+(defun socket-connect-internal (host &key port (protocol :stream) (element-type 'base-char)
                        timeout deadline (nodelay t)
                        local-host local-port)
   ;; What's the meaning of this keyword?

--- a/backend/lispworks.lisp
+++ b/backend/lispworks.lisp
@@ -519,8 +519,7 @@
        usocket))))
 
 (defun socket-listen-internal
-                          (host port
-                           &key reuseaddress
+                          (host &key port reuseaddress
                            (reuse-address nil reuse-address-supplied-p)
                            (backlog 5)
                            (element-type 'base-char))

--- a/backend/mcl.lisp
+++ b/backend/mcl.lisp
@@ -48,8 +48,7 @@
 			       :local-port local-port))))))
 
 (defun socket-listen-internal
-                          (host port
-                           &key reuseaddress
+                          (host &key port reuseaddress
                            (reuse-address nil reuse-address-supplied-p)
                            (backlog 5)
                            (element-type 'character))

--- a/backend/mcl.lisp
+++ b/backend/mcl.lisp
@@ -22,7 +22,7 @@
       (ccl:opentransport-protocol-error
        (raise-error 'protocol-not-supported-error)))))
 
-(defun socket-connect-internal (host port &key (element-type 'character) timeout deadline nodelay 
+(defun socket-connect-internal (host &key port (element-type 'character) timeout deadline nodelay
                             local-host local-port (protocol :stream))
   (when (eq nodelay :if-supported)
     (setf nodelay t))

--- a/backend/mezzano.lisp
+++ b/backend/mezzano.lisp
@@ -30,7 +30,7 @@
        ;; TODO:
        (unsupported 'datagram 'socket-connect)))))
 
-(defun socket-listen-internal (host port &key reuseaddress
+(defun socket-listen-internal (host &key port reuseaddress
                                (reuse-address nil reuse-address-supplied-p)
                                (backlog 5)
                                (element-type 'character))

--- a/backend/mezzano.lisp
+++ b/backend/mezzano.lisp
@@ -10,7 +10,7 @@
     (mezzano.network.tcp:connection-timed-out
      (error 'timeout-error :socket socket))))
 
-(defun socket-connect-internal (host port &key (protocol :stream) element-type
+(defun socket-connect-internal (host &key port (protocol :stream) element-type
                                       timeout deadline (nodelay nil nodelay-p)
                                       local-host local-port)
   (declare (ignore local-host local-port))

--- a/backend/mocl.lisp
+++ b/backend/mocl.lisp
@@ -7,7 +7,7 @@
   (declare (ignore socket))
   (signal condition))
 
-(defun socket-connect-internal (host port &key (protocol :stream) (element-type 'character)
+(defun socket-connect-internal (host &key port (protocol :stream) (element-type 'character)
                        timeout deadline (nodelay t nodelay-specified)
 		       (local-host nil local-host-p)
 		       (local-port nil local-port-p))

--- a/backend/mocl.lisp
+++ b/backend/mocl.lisp
@@ -33,8 +33,7 @@
               :context 'socket-connect)))))
 
 (defun socket-listen-internal
-                          (host port
-                           &key reuseaddress
+                          (host &key port reuseaddress
                            (reuse-address nil reuse-address-supplied-p)
                            (backlog 5)
                            (element-type 'character))

--- a/backend/openmcl.lisp
+++ b/backend/openmcl.lisp
@@ -127,8 +127,7 @@
 
 #-ipv6
 (defun socket-listen-internal
-                     (host port
-                      &key reuseaddress
+                     (host &key port reuseaddress
                            (reuse-address nil reuse-address-supplied-p)
                            (backlog 5)
                            (element-type 'character))

--- a/backend/openmcl.lisp
+++ b/backend/openmcl.lisp
@@ -89,7 +89,7 @@
 	 :bivalent)))
 
 #-ipv6
-(defun socket-connect-internal (host port &key (protocol :stream) element-type
+(defun socket-connect-internal (host &key port (protocol :stream) element-type
 		       timeout deadline nodelay
 		       local-host local-port)
   (when (eq nodelay :if-supported)

--- a/backend/sbcl.lisp
+++ b/backend/sbcl.lisp
@@ -408,7 +408,7 @@ happen. Use with care."
         (and (or ecl mkcl) (not (or darwin linux openbsd freebsd netbsd bsd))))
   nil)
 
-(defun socket-connect-internal (host port &key (protocol :stream) (element-type 'character)
+(defun socket-connect-internal (host &key port (protocol :stream) (element-type 'character)
                        timeout deadline (nodelay t nodelay-specified)
                        local-host local-port
                        &aux

--- a/backend/sbcl.lisp
+++ b/backend/sbcl.lisp
@@ -568,8 +568,7 @@ happen. Use with care."
     usocket))
 
 (defun socket-listen-internal
-                          (host port
-                           &key reuseaddress
+                          (host &key port reuseaddress
                            (reuse-address nil reuse-address-supplied-p)
                            (backlog 5)
                            (element-type 'character))

--- a/backend/scl.lisp
+++ b/backend/scl.lisp
@@ -87,8 +87,7 @@
 	 usocket)))))
 
 (defun socket-listen-internal
-                          (host port
-                           &key reuseaddress
+                          (host &key port reuseaddress
                            (reuse-address nil reuse-address-supplied-p)
                            (backlog 5)
                            (element-type 'character))

--- a/backend/scl.lisp
+++ b/backend/scl.lisp
@@ -25,7 +25,7 @@
 			   :socket socket
 			   :condition condition))))
 
-(defun socket-connect-internal (host port &key (protocol :stream) (element-type 'character)
+(defun socket-connect-internal (host &key port (protocol :stream) (element-type 'character)
                        timeout deadline (nodelay t nodelay-specified)
 		       (local-host nil local-host-p)
 		       (local-port nil local-port-p)

--- a/usocket.lisp
+++ b/usocket.lisp
@@ -789,7 +789,7 @@ backward compatibility (but deprecated); when both `reuseaddress' and
 ;;
 ;; This function is contributed by Mariano Montone (https://github.com/mmontone)
 ;;
-(defun socket-listen (host port  &rest args)
+(defun socket-listen (host &optional port  &rest args)
   (let ((socket-host host)
 	(socket-port port))
     (loop 
@@ -812,7 +812,7 @@ backward compatibility (but deprecated); when both `reuseaddress' and
         (retry ()
 	  :report "Retry socket connection.")))))
 
-(defun socket-connect (host port &rest args)
+(defun socket-connect (host &optional port &rest args)
   (let ((socket-host host)
 	    (socket-port port))
     (loop 

--- a/usocket.lisp
+++ b/usocket.lisp
@@ -794,7 +794,7 @@ backward compatibility (but deprecated); when both `reuseaddress' and
 	(socket-port port))
     (loop 
       (restart-case (return
-                     (apply #'socket-listen-internal socket-host socket-port args))
+                     (apply #'socket-listen-internal socket-host :port socket-port args))
 	(use-other-port (new-port) 
           :report "Use a different port." 
           :interactive 

--- a/usocket.lisp
+++ b/usocket.lisp
@@ -817,7 +817,7 @@ backward compatibility (but deprecated); when both `reuseaddress' and
 	    (socket-port port))
     (loop 
       (restart-case (return
-                      (apply #'socket-connect-internal socket-host socket-port args))
+                      (apply #'socket-connect-internal socket-host :port socket-port args))
 	    (use-other-port (new-port)
           :report "Use a different port." 
           :interactive 


### PR DESCRIPTION
A simple test case on SBCL 2.3.4 macOS 13.4.1:

```lisp
(defun userver ()
  (let ((socket (usocket:socket-listen #p"/tmp/uds")))
    (unwind-protect
         (loop
           (let* ((connection (usocket:socket-accept socket :element-type 'character))
                  (stream (usocket:socket-stream connection)))
             (format stream (read-line stream))
             (force-output stream)
             (usocket:socket-close connection)))
      (progn
        (usocket:socket-close socket)
        (uiop:delete-file-if-exists #p "/tmp/uds")))))

(defun create-userver ()
  (bt:make-thread
   #'userver
   :name "usocket-server"))

(defun client ()
  (usocket:with-client-socket (socket stream #p"/tmp/uds")
    (unwind-protect
         (progn
           (format stream "Hello~&")
           (force-output stream)
           (format t (read-line stream)))
      (usocket:socket-close socket))))
```