### PR TITLE
Convert (port/ip)-(to/from)-octet-buffer macros to inline functions

### DIFF
--- a/usocket.lisp
+++ b/usocket.lisp
@@ -447,21 +447,25 @@ the values documented in usocket.lisp in the usocket class."
       (setf (ldb (byte 8 i) integer)
             (aref buffer b)))))
 
-(defmacro port-to-octet-buffer (port buffer &key (start 0))
+(declaim (inline port-to-octet-buffer))
+(defun port-to-octet-buffer (port buffer &key (start 0))
   "Write an integer `port' into `buffer' as octets, starting at index `start', returning `buffer'."
-  `(integer-to-octet-buffer ,port ,buffer 2 :start ,start))
+  (integer-to-octet-buffer port buffer 2 :start start))
 
-(defmacro ip-to-octet-buffer (ip buffer &key (start 0))
+(declaim (inline ip-to-octet-buffer))
+(defun ip-to-octet-buffer (ip buffer &key (start 0))
   "Write an integer IP address `ip' into `buffer' as octets, starting at index `start', returning `buffer'"
-  `(integer-to-octet-buffer (host-byte-order ,ip) ,buffer 4 :start ,start))
+  (integer-to-octet-buffer (host-byte-order ip) buffer 4 :start start))
 
-(defmacro port-from-octet-buffer (buffer &key (start 0))
+(declaim (inline port-from-octet-buffer))
+(defun port-from-octet-buffer (buffer &key (start 0))
   "Read a port number from `buffer' at position `start', returning an integer."
-  `(octet-buffer-to-integer ,buffer 2 :start ,start))
+  (octet-buffer-to-integer buffer 2 :start start))
 
-(defmacro ip-from-octet-buffer (buffer &key (start 0))
+(declaim (inline ip-from-octet-buffer))
+(defun ip-from-octet-buffer (buffer &key (start 0))
   "Read an IP address from `buffer' at position `start', returning the IP address as an integer."
-  `(octet-buffer-to-integer ,buffer 4 :start ,start))
+  (octet-buffer-to-integer buffer 4 :start start))
 
 ;;
 ;; IPv4 utility functions


### PR DESCRIPTION
The following symbols are macros defined as thin wrappers around `octet-buffer-to-integer`:
+ port-to-octet-buffer
+ ip-to-octet-buffer
+ port-from-octet-buffer
+ ip-from-octet-buffer
These macros do no real syntax transformation. These forms would better serve the user as inline functions, which would provide nearly the same effect in reducing function call overhead, while also letting them be passed around easily as function objects.
Yeah I know kinda petty, but I figure there's not much risk of breakage and it'll make someone happy down the line