### PR TITLE
Add CLASP to sb-bsd-socket dependency

### DIFF
--- a/usocket.asd
+++ b/usocket.asd
@@ -18,7 +18,7 @@
     :licence "MIT"
     :description "Universal socket library for Common Lisp"
     :depends-on (:split-sequence
-                 (:feature (:and (:or :sbcl :ecl)
+                 (:feature (:and (:or :sbcl :ecl :clasp)
                                  (:not :usocket-iolib))
                   :sb-bsd-sockets)
                  (:feature :usocket-iolib


### PR DESCRIPTION
Clasp currently includes it in the kernel which why this has worked in the past. In case it gets removed from the kernel it will behave just like ECL.