### PR TITLE
[LW] revert broadcast hack

### DIFF
--- a/backend/clozure.lisp
+++ b/backend/clozure.lisp
@@ -44,7 +44,7 @@
                                       :format ,(to-format element-type protocol)
                                       :external-format ,ccl:*default-external-format*
                                       :deadline ,deadline
-                                      :nodelay ,nodelay
+                                      :nodelay ,(when (eql protocol :stream) nodelay)
                                       :connect-timeout ,timeout
                                       :input-timeout ,timeout))))
                (loop-finish)

--- a/backend/lispworks.lisp
+++ b/backend/lispworks.lisp
@@ -442,13 +442,6 @@
                                         :local-port local-port
                                         :read-timeout read-timeout
                                         :address-family address-family)))
-	;; For broadcast addresses, the broadcast option has to be set prior to COMM:CONNECT
-	(when (eql address-family comm::*socket_af_inet*)
-	  (let ((last-octet-pos (position #\. hostname :from-end t)))
-	    ;; Kludgy check for most broadcast IPv4 addresses in absence of netmask.
-	    ;; This will still fail with networks smaller than /24
-	    (when (and last-octet-pos (string= "255" (subseq hostname (1+ last-octet-pos))))
-              (set-socket-broadcast socket-fd 1))))
         (if socket-fd
             (if (comm::connect socket-fd server-addr server-addr-length)
                 ;; success, return socket fd


### PR DESCRIPTION
The broadcast hack for LispWorks is ultimately incorrect and should be reverted. I still have no satisfying solution to it but this kludge doesn't belong in USOCKET.