### PR TITLE
Bugfix for error sending a UDP datagram on CCL when host is a vector.

### DIFF
--- a/backend/openmcl.lisp
+++ b/backend/openmcl.lisp
@@ -123,7 +123,7 @@
 	      (usocket (make-datagram-socket mcl-sock)))
 	 (when (and host port)
 	   (ccl::inet-connect (ccl::socket-device mcl-sock)
-			      (ccl::host-as-inet-host host)
+			      (ccl::host-as-inet-host (host-to-hostname host))
 			      (ccl::port-as-inet-port port "udp")))
 	 (setf (connected-p usocket) t)
 	 usocket)))))


### PR DESCRIPTION
Description:

usocket versions: all versions I've tried from 0.6.1 to 0.8.8 CCL version: Version 1.10-r16196  (LinuxX8664)
In the latest CCL version (Version 1.13 (v1.13) LinuxX8664), usocket's buggy function  has apparently been superseded by an ipv6 function, which is why the bug doesn't appear there. But usocket's non-ipv6 function may as well also be fixed, e.g. for use on old (or other non-ipv6) CCL's.

Bug demonstration:

; first open a listening udp socket on port 12000, e.g. with
;   nc -l -u -p 12000
; then run this test
(defun test ()
  (let ((sock (socket-connect #(127 0 0 1) 12000 :protocol :datagram)))
    (unwind-protect
      (socket-send sock
                   (make-array 1 :element-type '(unsigned-byte 8)
                                 :initial-element #x61)
                   1)
      (sleep 1)
      (socket-close sock))))

Observe the unexpected error:

> Error: The value #<SIMPLE-VECTOR 4> is not of the expected type (OR INTEGER STRING).
> While executing: CCL::HOST-AS-INET-HOST, in process listener(1).