### PR TITLE
Bugfix: clisp ffi udp socket-send

### DIFF
--- a/backend/clisp.lisp
+++ b/backend/clisp.lisp
@@ -661,7 +661,7 @@ and the address of the sender as values."
 	     (fill-sockaddr_in (ffi:allocate-shallow 'sockaddr_in) host port)))
 	  (send-buffer
 	   (ffi:allocate-deep 'ffi:uint8
-			      (if (zerop offset)
+			      (if (and (zerop offset) (= size (length buffer)))
 				  buffer
 				  (subseq buffer offset (+ offset size)))
 			      :count size :read-only t))


### PR DESCRIPTION
socket-send takes a buffer argument and offset/size args to specify which part of the buffer to send. But the ffi:allocate-deep function that it calls apparently does not. Although that function takes a count argument, count does not mean how many bytes of the buffer it should copy. The count argument is meant to say how big the buffer is. It isn't allowed to be smaller than the buffer's length. The way socket-send is written, it passes a smaller count than the buffer's length, causing an error.

This patch fixes socket-send.

Here is a udp echo server demonstrating the failure that this patch fixes.

(defun handle-datagram (dg)
  (declare (type (simple-array (unsigned-byte 8) *) dg))
  (print (map 'string #'code-char dg))
  dg)

(defun start-socket-server ()
  (socket-server #(127 0 0 1) 12000 'handle-datagram nil
                 :in-new-thread nil
                 :protocol :datagram
                 :max-buffer-size 16))

(start-socket-server)

; from a separate shell send a udp datagram smaller than 16 bytes. ; echo x | nc -u localhost 12000
; to observe this error in lisp
; *** - FFI:FOREIGN-ALLOCATE: #(120 10 0 0 0 0 0 0 0 0 0 0 0 0 0 0) cannot be
;       converted to the foreign type #(FFI:C-ARRAY FFI:UINT8 2)