### PR TITLE
Fix: clisp ffi udp corrupt memory and descriptors

### DIFF
--- a/backend/clisp.lisp
+++ b/backend/clisp.lisp
@@ -612,8 +612,12 @@ and the address of the sender as values."
 
   (defmethod socket-close ((usocket datagram-usocket))
     (with-slots (recv-buffer socket) usocket
-      (ffi:foreign-free recv-buffer)
-      (zerop (%close socket))))
+      (when recv-buffer
+        (ffi:foreign-free recv-buffer)
+        (%close socket)
+        (setf recv-buffer nil
+              socket nil)
+        t)))
 
   (defmethod socket-receive ((usocket datagram-usocket) buffer length &key)
     (let ((remote-address (ffi:allocate-shallow 'sockaddr_in))


### PR DESCRIPTION
socket-close was not written to be called more than once. However a finalizer was installed to call it, even though the user might already have explicitly called it already. This patch rewrites it to be callable more than once.

The original socket-close did two things, both of which were problematic if done twice.
1) It called ffi:foreign-free, which is not allowed to be called twice, so
   produced a "double free or corruption" error from the underlying
   malloc.
2) It closed an underlying file descriptor, which again by the time of
   the second call, could have been re-alloted by the OS to a different
   socket that had no desire to be closed.

Demonstrating the bug:

Run a udp echo server listening on port 12000. Then,

```
(defun client (n delay-seconds)
  (dotimes (i n)
    (let ((sock (socket-connect #(127 0 0 1) 12000 :protocol :datagram)))
      (unwind-protect
        (socket-send sock (make-array 1 :element-type '(unsigned-byte 8)
                                        :initial-element #x61)
                          1)
        (sleep delay-seconds)
        (socket-close sock)))))

(client 2000 0.1)

```
Observe the "double free or corruption" error without this patch. The second bug above also exists but is masked by the first. If you wish to observe it, apply the patch but move the call to `%close` out of the conditional and don't set socket to nil. Observe "EBADF" the code for "bad-file-descriptor-error".

This patch fixes both bugs.