### PR TITLE
Improve clisp support

### DIFF
--- a/backend/clisp.lisp
+++ b/backend/clisp.lisp
@@ -107,6 +107,8 @@
   (let ((errno
           (cond
             ;clisp 2.49+
+            ((typep condition (find-symbol "OS-ERROR" "EXT"))
+             (ext:os-error-code condition))
             ((typep condition (find-symbol "OS-STREAM-ERROR" "EXT"))
              (parse-errno condition))
             ;clisp 2.49

--- a/option.lisp
+++ b/option.lisp
@@ -361,7 +361,7 @@
     #+allegro
     () ; TODO
     #+clisp
-    () ; TODO
+    (int->bool (socket:socket-options socket :so-keepalive))
     #+clozure
     (int->bool (get-socket-option-keep-alive socket))
     #+cmu
@@ -388,9 +388,9 @@
     #+abcl
     () ; TODO
     #+allegro
-    () ; TODO
+    (socket:set-socket-options socket :keepalive new-value)
     #+clisp
-    () ; TODO
+    (socket:socket-options socket :so-keepalive (bool->int new-value))
     #+clozure
     (set-socket-option-keep-alive socket (bool->int new-value))
     #+cmu


### PR DESCRIPTION
Handle socket error conditions that are subclasses of EXT:OS-ERROR. Add support for the socket keepalive option.

Also, add Allegro code for setting keepalive.