### PR TITLE
Patches 2026 04 take 1

### DIFF
--- a/backend/iolib.lisp
+++ b/backend/iolib.lisp
@@ -294,9 +294,9 @@ Backtrace:
     (unless (eq event-base *event-base*)
       (close event-base))))
 
-(defmethod socket-option ((socket usocket) option)
+(defmethod socket-option ((socket usocket) option &key)
   (iolib/sockets:socket-option (socket-stream socket) option))
 
-(defmethod (setf socket-option) (new-value (socket usocket) option)
+(defmethod (setf socket-option) (new-value (socket usocket) option &key)
   (let ((form `(setf (iolib/sockets:socket-option ,(socket-stream socket) ,option) ,new-value)))
     (eval (macroexpand-1 form))))

--- a/backend/iolib.lisp
+++ b/backend/iolib.lisp
@@ -294,7 +294,7 @@ Backtrace:
 (defun wait-for-input-internal (wait-list &key timeout)
   (let ((event-base (wait-list-%wait wait-list)))
     (handler-case
-	(iolib/multiplex:event-dispatch event-base :timeout timeout)
+	(iolib/multiplex:event-dispatch event-base :one-shot t :timeout timeout)
       (iolib/streams:hangup ())
       (end-of-file ()))
     ;; close the event-base after use

--- a/backend/iolib.lisp
+++ b/backend/iolib.lisp
@@ -307,3 +307,84 @@ Backtrace:
 (defmethod (setf socket-option) (new-value (socket usocket) option &key)
   (let ((form `(setf (iolib/sockets:socket-option ,(socket-stream socket) ,option) ,new-value)))
     (eval (macroexpand-1 form))))
+
+
+
+
+;;; ----------------------------------------------------------------------
+;;
+;; ;madhu 241117 - C `sendto' and `recvfrom' are not limited to datagram
+;; sockets.  We want to support socket-send and socket-receive on
+;; iolib :file (or :local) sockets
+;;
+;; IOLIB/SOCKETS:SEND-TO is defined on IOLIB/SOCKETS:INTERNET-SOCKET,
+;; and IOLIB/SOCKETS:LOCAL-SOCKET.
+;;
+;; and
+;;
+;; IOLIB/SOCKETS:RECEIVE-FROM is defined on
+;; IOLIB/SOCKETS:STREAM-SOCKET IOLIB/SOCKETS:RAW-SOCKET
+;; IOLIB/SOCKETS:DATAGRAM-SOCKET
+;;
+;; define methdods for USOCKET:SOCKET-SEND and USOCKET:SOCKET-RECV on
+;; USOCKET:USOCKET so iolib can call the c system calls.
+;;
+;; the calls on USOCKET:USOCKET-DATAGRAM objects will be dispacted as
+;; usual to that method.
+
+(defmacro with-ewouldblock-handled (&body body)
+  `(handler-bind ((iolib/syscalls:ewouldblock
+		   (lambda (c)
+		     (let ((r (find-restart 'iolib/sockets:retry-syscall c)))
+		       (cond (r
+			      (format t "ewouldblock handled~%")
+			      (invoke-restart r))
+			     (t (format t "ewouldblock: no restart!~%")))))))
+     ,@body))
+
+(defmacro with-ewouldblock-handled (&body body) `(progn ,@body))
+
+(defun maybe-pinned-array (array)
+  #+lispworks
+  (make-array (length array)
+	      #+lispworks :allocation
+	      #+lispworks :pinnable
+	      :element-type '(unsigned-byte 8)
+	      :initial-contents array)
+  #-lispworks
+  array)
+
+(defmethod socket-send ((usocket usocket) buffer size &key host port (offset 0))
+  (let* ((buffer (etypecase buffer
+		   (string
+		    (babel:string-to-octets buffer))
+		   ((simple-array (unsigned-byte 8))
+		    buffer)
+		   ((array (unsigned-byte 8))
+		    (make-array (length buffer)
+				:element-type '(unsigned-byte 8)
+				:initial-contents buffer))))
+	 (size (or size	;; better be coerrect, we expect nil
+		   (length buffer))))
+    #+lispworks
+    (setq buffer (maybe-pinned-array buffer))
+    (with-ewouldblock-handled
+      (apply #'iolib/sockets:send-to
+	     `(,(socket usocket) ,buffer :start ,offset :end ,(+ offset size)
+		:dont-wait t
+		,@(when (and host port)
+		    `(:remote-host ,(iolib/sockets:ensure-hostname host)
+		      :remote-port ,port)))))))
+
+;; lispworks8 requires buffer to be :pinnable
+(defmethod socket-receive ((usocket usocket) buffer length &key start end)
+  (multiple-value-bind (buffer size host port)
+      (with-ewouldblock-handled
+	(iolib/sockets:receive-from (socket usocket)
+				    :buffer buffer :size (or length (length buffer))
+				    :start (or start 0)
+				    :end (or end (length buffer))
+;; ???
+				    :dont-wait t
+				    ))
+    (values buffer size (if host (iolib-vector-to-vector-quad host)) port)))

--- a/backend/openmcl.lisp
+++ b/backend/openmcl.lisp
@@ -113,7 +113,7 @@
 	 (make-stream-socket :stream mcl-sock :socket mcl-sock)))
       (:datagram
        (let* ((mcl-sock
-	       (openmcl-socket:make-socket :address-family :internet
+	       (openmcl-socket:make-socket :address-family (if (pathnamep host) :file :internet)
 					   :type :datagram
 					   :local-host local-host
 					   :local-port local-port

--- a/backend/openmcl.lisp
+++ b/backend/openmcl.lisp
@@ -290,3 +290,73 @@
 (defun set-socket-option-keep-alive (socket value)
   (ccl::int-setsockopt (ccl::socket-device socket)
                                   #$SOL_SOCKET #$SO_KEEPALIVE value))
+
+
+;;; ----------------------------------------------------------------------
+;;; ;madhu 241117 - as C `send' and `recv' can work on non-datagram
+;;; sockets try to support those for USOCKET in Clozure.
+;;;
+
+(defmethod socket-send ((usocket usocket) buffer size &key host port (offset 0))
+  (when (or host port) (warn "socket-send: Ignoring host or port"))
+  (let* ((buffer (etypecase buffer
+		   (string
+		    (babel:string-to-octets buffer))
+		   ((simple-array (unsigned-byte 8))
+		    buffer)
+		   ((array (unsigned-byte 8))
+		    (make-array (length buffer)
+				:element-type '(unsigned-byte 8)
+				:initial-contents buffer))))
+	 (size (or size ;; we expect nil
+		   (length buffer))))
+    (let* ((socket (socket usocket))
+	   (fd (ccl::socket-device socket)))
+      (multiple-value-setq (buffer offset)
+	(ccl::verify-socket-buffer buffer offset size))
+      (ccl::%stack-block ((bufptr size))
+	(ccl::%copy-ivector-to-ptr buffer offset bufptr 0 size)
+	(ccl::socket-call socket "send"
+			  (ccl::with-eagain fd :output
+			    (ccl::ignoring-eintr
+			      (ccl::check-socket-error (#_send fd bufptr size 0)))))))))
+
+(defmethod ccl::socket-format ((stream CCL::FUNDAMENTAL-FILE-SOCKET-STREAM))
+  :binary
+  #+nil
+  (if (eq (stream-element-type stream) 'character)
+    :text
+    :bivalent))
+
+(defmethod socket-receive ((usocket usocket) buffer size &key (offset 0) extract)
+  (unless size (setq size (length buffer)))
+  (with-mapped-conditions (usocket)
+    (let* ((socket (socket usocket))
+	   (fd (ccl::socket-device socket))
+	   (vec-offset offset)
+	   (vec buffer)
+	   (ret-size -1))
+      (when vec
+	(multiple-value-setq (vec vec-offset)
+	  (ccl::verify-socket-buffer vec vec-offset size)))
+      (ccl::%stack-block ((bufptr size))
+	(setq ret-size (ccl::socket-call socket "recv"
+					 (ccl::with-eagain fd :input
+					   (#_recv fd bufptr size 0))))
+	(unless vec
+	  (setq vec (make-array ret-size
+				:element-type
+				(ecase (ccl::socket-format socket)
+				  ((:binary) '(unsigned-byte 8))))
+		vec-offset 0))
+	(ccl::%copy-ptr-to-ivector bufptr 0 vec vec-offset ret-size))
+      (let* ((buffer (cond ((null buffer)
+                            vec)
+                           ((or (not extract)
+				(and (eql 0 (or offset 0))
+				     (eql ret-size (length buffer))))
+                            buffer)
+                           (t
+                             (subseq vec vec-offset (+ vec-offset ret-size))))))
+	(values buffer ret-size)))))
+

--- a/backend/sbcl.lisp
+++ b/backend/sbcl.lisp
@@ -592,7 +592,7 @@ happen. Use with care."
            (setf ok t))
       ;; Clean up in case of an error.
       (unless ok
-        (sb-bsd-sockets:socket-close socket :abort t)))
+        (sb-bsd-sockets:socket-close socket #-mkcl :abort #-mkcl t)))
     usocket))
 
 (defun socket-listen-internal

--- a/backend/sbcl.lisp
+++ b/backend/sbcl.lisp
@@ -1148,3 +1148,34 @@ happen. Use with care."
            (sb-bsd-sockets::socket-error 'wait-for-input-internal))))))
 
 ) ; progn
+
+
+;;; ----------------------------------------------------------------------
+;;; ;madhu 241117
+;;; try to allow `sendto' and `recvfrom' on unix domain sockets
+;;;
+
+(defmethod socket-send ((usocket usocket) buffer size &key host port (offset 0))
+  (let ((remote (when host
+                  (car (get-hosts-by-name (host-to-hostname host))))))
+    (with-mapped-conditions (usocket host)
+      (let* ((s (socket usocket))
+             (dest (if (and host port) (list remote port) nil))
+             (real-buffer (if (zerop offset)
+                              buffer
+                              (subseq buffer offset (+ offset size)))))
+        (sb-bsd-sockets:socket-send s real-buffer size :address dest)))))
+
+(defmethod socket-receive ((usocket usocket) buffer length
+                           &key (element-type '(unsigned-byte 8)))
+  (with-mapped-conditions (usocket)
+    (let ((s (socket usocket)))
+      (multiple-value-bind (buf len peer)
+	  (sb-bsd-sockets:socket-receive s buffer length :element-type element-type)
+	(declare (ignore peer))
+	(assert (eql buf buffer))
+	(values
+	 #|| (cond ((= (length buf) len)
+		buf)
+		(t (subseq buf 0 len)))	||#
+	 buffer	len)))))

--- a/usocket.asd
+++ b/usocket.asd
@@ -18,6 +18,7 @@
     :licence "MIT"
     :description "Universal socket library for Common Lisp"
     :depends-on (:split-sequence
+		 :babel
                  (:feature (:and (:or :sbcl :ecl :clasp)
                                  (:not :usocket-iolib))
                   :sb-bsd-sockets)


### PR DESCRIPTION
Hello, this pr is intended to replace the "usocket-iolib" branch which was created to help
test merge my patches, it separates out the patch into multiple commits and they are not
limited to the iolib backend' the usocket-iolib branch should be deleted.

there are fixes for usocket-iolib which makes it work with passive sockets
(a patched hunchentoot could possibly use the usocket-iolib backend)

 I've also tried to 
- add support for socket-connect to unix domain sockets for ccl (native) and iolib
- extend socket-send and socket-receive methods to work on unix domain sockets.
(though I suppose iolib only supports connectiong to local sockets)

please review and test, thanks